### PR TITLE
Refactor with new appearance

### DIFF
--- a/MMM-nextbike.css
+++ b/MMM-nextbike.css
@@ -1,17 +1,20 @@
-.MMM-nextbike .table {
-    border-spacing: 0px 0px;
-    border-collapse: separate;
-    text-align: left;
-	width: 220px;
-	}
+.MMM-nextbike .stationsList {
+	list-style: none;
+}
 
-.MMM-nextbike .spacerRow {
-	padding-bottom: 5px;
-	}
+.MMM-nextbike .stationName {
+	text-transform: uppercase;
+}
 
-.MMM-nextbike .amountRow {
-	
-	font-weight: normal;
+.MMM-nextbike .stationInfo {
+	padding-left: 4px;
+	color: #c1c1c1;
+}
+
+.MMM-nextbike .stationInfo .available-bikes {
+	font-size: 1.75rem;
 	color: white;
-	}
-
+}
+.MMM-nextbike .stationInfo .total-bikes {
+	font-size: 0.85rem;
+}

--- a/MMM-nextbike.css
+++ b/MMM-nextbike.css
@@ -1,5 +1,10 @@
+.MMM-nextbike header {
+	margin-bottom: 4px;
+}
+
 .MMM-nextbike .stationsList {
 	list-style: none;
+	margin: 6px 0;
 }
 
 .MMM-nextbike .stationName {

--- a/MMM-nextbike.js
+++ b/MMM-nextbike.js
@@ -49,7 +49,7 @@ Module.register("MMM-nextbike", {
     if (!!this.nextbikeData && !!this.config.showHeader) {
       var header = document.createElement("header");
       var headerLabel =
-        (this.nextbikeData && this.nextbikeData.city.$.maps_icon) || "Nextbike";
+        (this.nextbikeData && this.nextbikeData.name) || "Nextbike";
       header.innerHTML = `<i class="fas fa-bicycle"></i> ${headerLabel}`;
       wrapper.appendChild(header);
     }

--- a/MMM-nextbike.js
+++ b/MMM-nextbike.js
@@ -42,17 +42,14 @@ Module.register("MMM-nextbike", {
     }
   },
 
+  getHeader: function() {
+    var headerLabel = (this.nextbikeData && this.nextbikeData.name);
+    return headerLabel && `<i class="fas fa-bicycle"></i> ${headerLabel}`;
+  },
+
   getDom: function () {
     // Auto-create MagicMirror header
     var wrapper = document.createElement("div");
-
-    if (!!this.nextbikeData && !!this.config.showHeader) {
-      var header = document.createElement("header");
-      var headerLabel =
-        (this.nextbikeData && this.nextbikeData.name) || "Nextbike";
-      header.innerHTML = `<i class="fas fa-bicycle"></i> ${headerLabel}`;
-      wrapper.appendChild(header);
-    }
 
     // Loading data notification
     if (!this.nextbikeData) {

--- a/MMM-nextbike.js
+++ b/MMM-nextbike.js
@@ -13,7 +13,8 @@ Module.register("MMM-nextbike", {
     stationName: "nextbike",
     showBikes: true,
     nob: "",
-    reload: 1 * 60 * 1000 // every minute
+    reload: 1 * 60 * 1000, // every minute
+    showHeader: true,
   },
 
   getTranslations: function () {
@@ -49,13 +50,16 @@ Module.register("MMM-nextbike", {
     // Auto-create MagicMirror header
 
     var wrapper = document.createElement("div");
-    var header = document.createElement("header");
-    if (this.config.stationName !== "nextbike") {
-      header.innerHTML = this.config.stationName;
-    } else {
-      header.innerHTML = this.config.stationName;
+
+    if (this.config.showHeader) {
+      var header = document.createElement("header");
+      if (this.config.stationName !== "nextbike") {
+        header.innerHTML = this.config.stationName;
+      } else {
+        header.innerHTML = this.config.stationName;
+      }
+      wrapper.appendChild(header);
     }
-    wrapper.appendChild(header);
 
     // Loading data notification
 
@@ -124,8 +128,7 @@ Module.register("MMM-nextbike", {
     if (!this.nextbikeData.bike_numbers) {
       amount.innerHTML = this.translate("NO-BIKES-AVAILABLE");
     } else {
-      amount.innerHTML =
-        this.translate("BIKES-AVAILABLE") + " " + this.nextbikeData.bikes;
+      amount.innerHTML = this.translate("BIKES-AVAILABLE") + " " + this.nextbikeData.bikes;
     }
     amountRow.appendChild(amount);
 

--- a/MMM-nextbike.js
+++ b/MMM-nextbike.js
@@ -8,13 +8,12 @@
 Module.register("MMM-nextbike", {
   defaults: {
     apiBase: "http://api.nextbike.net/maps/nextbike-official.xml",
-    cityID: 1,
-    stationID: 16337,
-    stationName: "nextbike",
+    cityId: "1",
+    stations: [{ id: "16337", name: "nextbike" }],
     showBikes: true,
     nob: "",
     reload: 1 * 60 * 1000, // every minute
-    showHeader: true,
+    showHeader: true
   },
 
   getTranslations: function () {
@@ -39,19 +38,17 @@ Module.register("MMM-nextbike", {
   },
 
   socketNotificationReceived: function (notification, payload) {
-    if (notification === "BIKES" + this.config.stationID) {
-      this.nextbikeData = payload.markers.country[0].city[0].place[0].$;
-      this.config.stationName = this.nextbikeData.name;
+    if (notification === "BIKES" + this.config.cityId) {
+      this.nextbikeData = payload;
       this.updateDom();
     }
   },
 
   getDom: function () {
     // Auto-create MagicMirror header
-
     var wrapper = document.createElement("div");
 
-    if (this.config.showHeader) {
+    if (!!this.config.showHeader) {
       var header = document.createElement("header");
       if (this.config.stationName !== "nextbike") {
         header.innerHTML = this.config.stationName;
@@ -62,93 +59,45 @@ Module.register("MMM-nextbike", {
     }
 
     // Loading data notification
-
     if (!this.nextbikeData) {
       var text = document.createElement("div");
       text.innerHTML = this.translate("LOADING");
       text.className = "small dimmed";
       wrapper.appendChild(text);
     } else {
-      // Create bike table once data is received
+      // Create stations list
+      var stationsList = document.createElement("ul");
+      stationsList.className = "small stationsList";
+      
+      this.nextbikeData.forEach(station => {
+        Log.info(station);
+        var stationConfig = this.getStationConfig(station);
+        var stationElement = document.createElement("li");
+        stationElement.className = "stationElement";
 
-      var table = document.createElement("table");
-      table.classList.add("small", "table");
-      table.border = "0";
-      table.appendChild(this.createSpacerRow());
-      table.appendChild(this.createAmountRow());
-      table.appendChild(this.createSpacerRow());
+        var stationName = document.createElement("span")
+        stationName.className = "stationLabel dimmed";
+        stationName.innerHTML = `<span class="stationName">${stationConfig.name}</span> <i class="fa fa-bicycle"></i> `;
+        stationElement.appendChild(stationName);
 
-      // List available bikes via a bike array
-
-      if (this.config.showBikes) {
-        // Make sure user wants to see the bikes
-
-        if (!this.nextbikeData.bike_numbers) {
-          this.hide(10000);
+        var stationInfo = document.createElement("span");
+        stationInfo.className = "stationInfo";
+        if (!station.$.bike_numbers) {
+          stationInfo.innerHTML = this.translate("NO-BIKES-AVAILABLE");
         } else {
-          if (this.hidden) {
-            this.show(5000);
-          }
-
-          var bikeArray = this.nextbikeData.bike_numbers.split(",");
-          if (!this.config.nob) {
-            this.config.nob = 100;
-          }
-          for (var i = 0; i < bikeArray.length && i < this.config.nob; i++) {
-            var bikeNumber = bikeArray[i];
-            table.appendChild(this.createDataRow(bikeNumber));
-          }
+          stationInfo.innerHTML = `<span class="available-bikes">${station.$.bikes}</span> / <span class="total-bikes">${station.$.bike_racks}</span>`;
         }
-      }
+        stationElement.appendChild(stationInfo);
+        stationsList.appendChild(stationElement);
+      });
 
-      wrapper.appendChild(table);
+      wrapper.appendChild(stationsList);
     }
 
     return wrapper;
   },
 
-  createSpacerRow: function () {
-    var spacerRow = document.createElement("tr");
-
-    var spacerHeader = document.createElement("td");
-    spacerHeader.className = "spacerRow";
-    spacerHeader.setAttribute("colSpan", "2");
-    spacerHeader.innerHTML = "";
-    spacerRow.appendChild(spacerHeader);
-
-    return spacerRow;
+  getStationConfig: function (station) {
+    return this.config.stations.find(config => config.id == station.$.uid);
   },
-
-  createAmountRow: function () {
-    var amountRow = document.createElement("tr");
-
-    var amount = document.createElement("td");
-    amount.className = "amountRow";
-    amount.setAttribute("colSpan", "2");
-    if (!this.nextbikeData.bike_numbers) {
-      amount.innerHTML = this.translate("NO-BIKES-AVAILABLE");
-    } else {
-      amount.innerHTML = this.translate("BIKES-AVAILABLE") + " " + this.nextbikeData.bikes;
-    }
-    amountRow.appendChild(amount);
-
-    return amountRow;
-  },
-
-  createDataRow: function (data) {
-    var row = document.createElement("tr");
-
-    var symbol = document.createElement("td");
-    symbol.setAttribute("width", "8px");
-    symbol.className = "fa fa-bicycle";
-    row.appendChild(symbol);
-
-    var bikeNo = document.createElement("td");
-    bikeNo.className = "bikeNo";
-    bikeNo.innerHTML = data;
-
-    row.appendChild(bikeNo);
-
-    return row;
-  }
 });

--- a/MMM-nextbike.js
+++ b/MMM-nextbike.js
@@ -6,153 +6,146 @@
  */
 
 Module.register("MMM-nextbike", {
+  defaults: {
+    apiBase: "http://api.nextbike.net/maps/nextbike-official.xml",
+    cityID: 1,
+    stationID: 16337,
+    stationName: "nextbike",
+    showBikes: true,
+    nob: "",
+    reload: 1 * 60 * 1000 // every minute
+  },
 
-    defaults: {
-		apiBase: 'http://api.nextbike.net/maps/nextbike-official.xml',
-		cityID: 1,
-		stationID: 16337,
-		stationName: 'nextbike',
-		showBikes: true,
-		nob: '',
-        reload: 1 * 60 * 1000       // every minute
-    },
+  getTranslations: function () {
+    return {
+      en: "translations/en.json",
+      es: "translations/es.json",
+      de: "translations/de.json"
+    };
+  },
 
-    getTranslations: function () {
-        return {
-            en: "translations/en.json",
-            es: "translations/es.json",
-            de: "translations/de.json"
-        };
-    },
+  getStyles: function () {
+    return ["MMM-nextbike.css", "font-awesome.css"];
+  },
 
-    getStyles: function () {
-        return ["MMM-nextbike.css", "font-awesome.css"];
-    },
+  start: function () {
+    var self = this;
+    Log.info("Starting module: " + this.name);
+    this.sendSocketNotification("CONFIG", this.config);
+    setInterval(function () {
+      self.sendSocketNotification("CONFIG", self.config);
+    }, this.config.reload);
+  },
 
-    start: function () {
-		var self = this;
-        Log.info("Starting module: " + this.name);
-        this.sendSocketNotification("CONFIG", this.config);
-		setInterval(
-			function()
-			{self.sendSocketNotification("CONFIG", self.config);}
-			,this.config.reload);
-    },
+  socketNotificationReceived: function (notification, payload) {
+    if (notification === "BIKES" + this.config.stationID) {
+      this.nextbikeData = payload.markers.country[0].city[0].place[0].$;
+      this.config.stationName = this.nextbikeData.name;
+      this.updateDom();
+    }
+  },
 
-		
-    socketNotificationReceived: function (notification, payload) {
-		if (notification === "BIKES" + this.config.stationID) {
-			this.nextbikeData = payload.markers.country[0].city[0].place[0].$;
-			this.config.stationName = this.nextbikeData.name;
-			this.updateDom();			
-	    }
-	},
+  getDom: function () {
+    // Auto-create MagicMirror header
 
-    getDom: function () {
-					
-		// Auto-create MagicMirror header
+    var wrapper = document.createElement("div");
+    var header = document.createElement("header");
+    if (this.config.stationName !== "nextbike") {
+      header.innerHTML = this.config.stationName;
+    } else {
+      header.innerHTML = this.config.stationName;
+    }
+    wrapper.appendChild(header);
 
-		var wrapper = document.createElement("div");
-        var header = document.createElement("header");
-		if (this.config.stationName !== "nextbike") { 
-        header.innerHTML = this.config.stationName;
-		} else {
-		header.innerHTML = this.config.stationName;
-		}
-        wrapper.appendChild(header);
-	
-		// Loading data notification
-		
-	    if (!this.nextbikeData) {
-			var text = document.createElement("div");
-            text.innerHTML = this.translate("LOADING");
-            text.className = "small dimmed";
-            wrapper.appendChild(text);
-        
-		} else {
-			
-		// Create bike table once data is received
-			
-			var table = document.createElement("table");
-			table.classList.add("small", "table");
-			table.border='0';
-			table.appendChild(this.createSpacerRow());
-			table.appendChild(this.createAmountRow());
-			table.appendChild(this.createSpacerRow());
-						
-		// List available bikes via a bike array
-		
-		if (this.config.showBikes)	{	// Make sure user wants to see the bikes
-		
-			if (!this.nextbikeData.bike_numbers){
-				this.hide(10000);						
-			} else {
-				
-				if (this.hidden) {
-					this.show(5000);
-				} 
-				
-				var bikeArray = this.nextbikeData.bike_numbers.split(",");
-				if (!this.config.nob) {this.config.nob = 100;}
-				for (var i=0; (i<bikeArray.length) && (i<this.config.nob);i++){
-					var bikeNumber = bikeArray[i];
-					table.appendChild(this.createDataRow(bikeNumber));	
-				}
-			}
-			
-		}
-			
-		wrapper.appendChild(table);
-				
-		}
-		
-		return wrapper; 
-		
-	},
-	
-	createSpacerRow: function () {
-        var spacerRow = document.createElement("tr");
-		
-		var spacerHeader = document.createElement("td");
-		spacerHeader.className = "spacerRow";
-		spacerHeader.setAttribute("colSpan", "2");
-		spacerHeader.innerHTML = "";
-		spacerRow.appendChild(spacerHeader); 
-      	
-		return spacerRow;
-    },
-	
-		createAmountRow: function () {
-        var amountRow = document.createElement("tr");
-		
-		var amount = document.createElement("td");
-		amount.className = "amountRow";
-		amount.setAttribute("colSpan", "2");
-		if (!this.nextbikeData.bike_numbers){
-			amount.innerHTML = this.translate("NO-BIKES-AVAILABLE");
-		} else {
-			amount.innerHTML = this.translate("BIKES-AVAILABLE") + " " + this.nextbikeData.bikes;
-		}
-		amountRow.appendChild(amount); 
-      	
-		return amountRow;
-    },
+    // Loading data notification
 
-    createDataRow: function (data) {
-        var row = document.createElement("tr");
-		
-		var symbol =  document.createElement("td");
-		symbol.setAttribute("width","8px");
-		symbol.className = "fa fa-bicycle";
-		row.appendChild(symbol);
-				
-		var bikeNo = document.createElement("td");
-		bikeNo.className = "bikeNo";
-        bikeNo.innerHTML = data;
-		
-        row.appendChild(bikeNo);
-		
-        return row;
+    if (!this.nextbikeData) {
+      var text = document.createElement("div");
+      text.innerHTML = this.translate("LOADING");
+      text.className = "small dimmed";
+      wrapper.appendChild(text);
+    } else {
+      // Create bike table once data is received
+
+      var table = document.createElement("table");
+      table.classList.add("small", "table");
+      table.border = "0";
+      table.appendChild(this.createSpacerRow());
+      table.appendChild(this.createAmountRow());
+      table.appendChild(this.createSpacerRow());
+
+      // List available bikes via a bike array
+
+      if (this.config.showBikes) {
+        // Make sure user wants to see the bikes
+
+        if (!this.nextbikeData.bike_numbers) {
+          this.hide(10000);
+        } else {
+          if (this.hidden) {
+            this.show(5000);
+          }
+
+          var bikeArray = this.nextbikeData.bike_numbers.split(",");
+          if (!this.config.nob) {
+            this.config.nob = 100;
+          }
+          for (var i = 0; i < bikeArray.length && i < this.config.nob; i++) {
+            var bikeNumber = bikeArray[i];
+            table.appendChild(this.createDataRow(bikeNumber));
+          }
+        }
+      }
+
+      wrapper.appendChild(table);
     }
 
+    return wrapper;
+  },
+
+  createSpacerRow: function () {
+    var spacerRow = document.createElement("tr");
+
+    var spacerHeader = document.createElement("td");
+    spacerHeader.className = "spacerRow";
+    spacerHeader.setAttribute("colSpan", "2");
+    spacerHeader.innerHTML = "";
+    spacerRow.appendChild(spacerHeader);
+
+    return spacerRow;
+  },
+
+  createAmountRow: function () {
+    var amountRow = document.createElement("tr");
+
+    var amount = document.createElement("td");
+    amount.className = "amountRow";
+    amount.setAttribute("colSpan", "2");
+    if (!this.nextbikeData.bike_numbers) {
+      amount.innerHTML = this.translate("NO-BIKES-AVAILABLE");
+    } else {
+      amount.innerHTML =
+        this.translate("BIKES-AVAILABLE") + " " + this.nextbikeData.bikes;
+    }
+    amountRow.appendChild(amount);
+
+    return amountRow;
+  },
+
+  createDataRow: function (data) {
+    var row = document.createElement("tr");
+
+    var symbol = document.createElement("td");
+    symbol.setAttribute("width", "8px");
+    symbol.className = "fa fa-bicycle";
+    row.appendChild(symbol);
+
+    var bikeNo = document.createElement("td");
+    bikeNo.className = "bikeNo";
+    bikeNo.innerHTML = data;
+
+    row.appendChild(bikeNo);
+
+    return row;
+  }
 });

--- a/MMM-nextbike.js
+++ b/MMM-nextbike.js
@@ -10,8 +10,6 @@ Module.register("MMM-nextbike", {
     apiBase: "http://api.nextbike.net/maps/nextbike-official.xml",
     cityId: "1",
     stations: [{ id: "16337", name: "nextbike" }],
-    showBikes: true,
-    nob: "",
     reload: 1 * 60 * 1000, // every minute
     showHeader: true
   },
@@ -48,13 +46,11 @@ Module.register("MMM-nextbike", {
     // Auto-create MagicMirror header
     var wrapper = document.createElement("div");
 
-    if (!!this.config.showHeader) {
+    if (!!this.nextbikeData && !!this.config.showHeader) {
       var header = document.createElement("header");
-      if (this.config.stationName !== "nextbike") {
-        header.innerHTML = this.config.stationName;
-      } else {
-        header.innerHTML = this.config.stationName;
-      }
+      var headerLabel =
+        (this.nextbikeData && this.nextbikeData.city.$.maps_icon) || "Nextbike";
+      header.innerHTML = `<i class="fas fa-bicycle"></i> ${headerLabel}`;
       wrapper.appendChild(header);
     }
 
@@ -68,16 +64,15 @@ Module.register("MMM-nextbike", {
       // Create stations list
       var stationsList = document.createElement("ul");
       stationsList.className = "small stationsList";
-      
-      this.nextbikeData.forEach(station => {
-        Log.info(station);
+
+      this.nextbikeData.stations.forEach((station) => {
         var stationConfig = this.getStationConfig(station);
         var stationElement = document.createElement("li");
         stationElement.className = "stationElement";
 
-        var stationName = document.createElement("span")
+        var stationName = document.createElement("span");
         stationName.className = "stationLabel dimmed";
-        stationName.innerHTML = `<span class="stationName">${stationConfig.name}</span> <i class="fa fa-bicycle"></i> `;
+        stationName.innerHTML = `<span class="stationName">${stationConfig.name}</span> `;
         stationElement.appendChild(stationName);
 
         var stationInfo = document.createElement("span");
@@ -93,11 +88,10 @@ Module.register("MMM-nextbike", {
 
       wrapper.appendChild(stationsList);
     }
-
     return wrapper;
   },
 
   getStationConfig: function (station) {
-    return this.config.stations.find(config => config.id == station.$.uid);
-  },
+    return this.config.stations.find((config) => config.id == station.$.uid);
+  }
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -5,57 +5,52 @@
  * MIT Licensed.
  */
 
-var parseString = require('xml2js').parseString;
-const request = require('request');
+var parseString = require("xml2js").parseString;
+const request = require("request");
 const NodeHelper = require("node_helper");
 
-
-
 module.exports = NodeHelper.create({
+  start: function () {
+    console.log("Starting node helper for: " + this.name);
+  },
 
-    start: function() {
-        console.log("Starting node helper for: " + this.name);
-    },
+  /* getParams
+   * Generates an url with api parameters based on the config.
+   *
+   * return String - URL params.
+   */
 
-	
-	/* getParams
-	 * Generates an url with api parameters based on the config.
-	 *
-	 * return String - URL params.
-	 */
-	
-	getParams: function() {
-			var params = "?city=";
-			params += this.config.cityID;
-			params += "&place=";
-			params += this.config.stationID;
-			return params;
-	},
-	
-    socketNotificationReceived: function(notification, payload) {
-        if(notification === 'CONFIG'){
-            this.config = payload;
-			var nextbike_url = this.config.apiBase + this.getParams();
-			this.getData(nextbike_url, this.config.stationID);
-        }
-    },
+  getParams: function () {
+    var params = "?city=";
+    params += this.config.cityId;
+    return params;
+  },
 
-	parseData: function(input) {
-				var nextbikeData = "";
-				parseString(input, function (err, result) {
-				nextbikeData = JSON.parse(JSON.stringify(result));
-				});
-				return nextbikeData;
-	},
-	
-	
-    getData: function(options, stationID) {
-		request(options, (error, response, body) => {
-	        if (response.statusCode === 200) {
-				this.sendSocketNotification("BIKES" + stationID, this.parseData(body));
-				} else {
-                console.log("Error getting nextbike data " + response.statusCode);
-            }
-        });
+  socketNotificationReceived: function (notification, payload) {
+    if (notification === "CONFIG") {
+      this.config = payload;
+      var nextbike_url = this.config.apiBase + this.getParams();
+      this.getData(nextbike_url, this.config.cityId);
     }
+  },
+
+  parseData: function (input) {
+    var nextbikeData = "";
+    parseString(input, function (err, result) {
+      nextbikeData = JSON.parse(JSON.stringify(result));
+	});
+	var stations = nextbikeData.markers.country[0].city[0].place;
+	var stationIds = this.config.stations.map(station => station.id);
+	return stations.filter(station => stationIds.includes(station.$.uid));
+  },
+
+  getData: function (options, cityId) {
+    request(options, (error, response, body) => {
+      if (response.statusCode === 200) {
+        this.sendSocketNotification("BIKES" + cityId, this.parseData(body));
+      } else {
+        console.log("Error getting nextbike data " + response.statusCode);
+      }
+    });
+  }
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -39,9 +39,10 @@ module.exports = NodeHelper.create({
     parseString(input, function (err, result) {
       nextbikeData = JSON.parse(JSON.stringify(result));
     });
-    var city = nextbikeData.markers.country[0].city[0];
+    var country = nextbikeData.markers.country[0];
+    var city = country.city[0];
     var stations = city.place.filter(station => this.getStationIds().includes(station.$.uid));
-    return { city, stations };
+    return { name: country.$.name, city, stations };
   },
 
   getData: function (options, cityId) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -5,7 +5,7 @@
  * MIT Licensed.
  */
 
-var parseString = require("xml2js").parseString;
+const parseString = require("xml2js").parseString;
 const request = require("request");
 const NodeHelper = require("node_helper");
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -38,10 +38,10 @@ module.exports = NodeHelper.create({
     var nextbikeData = "";
     parseString(input, function (err, result) {
       nextbikeData = JSON.parse(JSON.stringify(result));
-	});
-	var stations = nextbikeData.markers.country[0].city[0].place;
-	var stationIds = this.config.stations.map(station => station.id);
-	return stations.filter(station => stationIds.includes(station.$.uid));
+    });
+    var city = nextbikeData.markers.country[0].city[0];
+    var stations = city.place.filter(station => this.getStationIds().includes(station.$.uid));
+    return { city, stations };
   },
 
   getData: function (options, cityId) {
@@ -52,5 +52,9 @@ module.exports = NodeHelper.create({
         console.log("Error getting nextbike data " + response.statusCode);
       }
     });
+  },
+
+  getStationIds: function() {
+    return this.config.stations.map(station => station.id);
   }
 });


### PR DESCRIPTION
Instead of showing an unnecessary list of Bikes, I've changed the appearance and layout of the module.

Now it just shows a simple number with the `available / total` values for each configured station.

I've also changed the way it retrieves the info from the API, now it gets a full list of places and then filter them based on the `config.stations` value, which will be used to define the list of stations to be shown.

With the following config:
```
{
	module: 'MMM-nextbike',
	position: 'right_bottom',
	config: {
		cityId: '532',
		stations: [
			{ id: '9018817', name: "Epalza" },
			{ id: '8922848', name: "Ayuntamiento" }
		],
		showHeader: true,
	}
},
```

The output is the one in this screenshot, where you can see an example of the new appearance:
![image](https://user-images.githubusercontent.com/1290374/98049922-f30e5b80-1e30-11eb-9e51-8155fe1f899d.png)
